### PR TITLE
Added EmptyDataDecls Language Extension

### DIFF
--- a/lib/Assembler.hs
+++ b/lib/Assembler.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE DeriveDataTypeable, RecursiveDo #-}
+{-# LANGUAGE DeriveDataTypeable, RecursiveDo, EmptyDataDecls #-}
 
 module Assembler (
     Assemblage, assemblage_annotations, assemblage_start, assemblage_end, assemblage_result,


### PR DESCRIPTION
I was getting the following error while building the `Assembler` module:

```
lib/Assembler.hs:167:1:
    ‘Unknown’ has no constructors (EmptyDataDecls permits this)
    In the data declaration for ‘Unknown’
```

So I added `EmptyDataDecls` to the LANGUAGE pragma.
